### PR TITLE
Add Chicago to the list of sites

### DIFF
--- a/data/events.yml
+++ b/data/events.yml
@@ -49,3 +49,9 @@ peer_labs:
     meetup_url: https://www.meetup.com/IOS-peer-Lab-Chennai/
     contact_twitter: rshankra
     contact_email: ravi@rshankar.com
+
+  - city: Chicago
+    schedule: 5:00pm - 8:00pm Tuesdays on which NSCoder Nights or CocoaHeads are NOT scheduled.
+    location: FastModel Sports. 410 N. Michigan Ave Suite 320
+    contact_twitter: _aijaz_
+    contact_email: aijaz@aijaz.net


### PR DESCRIPTION
I've added Chicago to the list of sites. I don't want to conflict with the other great events we have here, (NSCoder Nights and Cocoaheads), so I'm scheduling them for weeks that we **don't** have either of those two events. 