### PR TITLE
Changed information for Chicago

### DIFF
--- a/data/events.yml
+++ b/data/events.yml
@@ -62,10 +62,8 @@ peer_labs:
 
   - city: Chicago
     schedule: 5:00pm - 8:00pm Tuesdays on which NSCoder Nights or CocoaHeads are NOT scheduled.
-    location: FastModel Sports. 444 N. Michigan Ave Suite 760
     meetup_url: http://peerlabchicago.com/
-    contact_twitter: _aijaz_
-    contact_email: aijaz@aijaz.net
+    contact_twitter: peerlabchicago
 
   - city: Moscow, Russia
     schedule: Every Saturday, 11:00am


### PR DESCRIPTION
I'm moving out of Chicago, so I changed the contact information to the peerlab account as opposed to my personal contact information.