### PR TITLE
Add space between email and telegram handle

### DIFF
--- a/source/find.html.erb
+++ b/source/find.html.erb
@@ -41,6 +41,8 @@ title: Find a Peer Lab
                 <% end %>
                 <% if event.contact_email && event.contact_twitter %>
                   <% contact += ' or ' %>
+		<% else %>
+                  <% contact += '. ' %>
                 <% end %>
                 <% if event.contact_twitter && event.contact_twitter.is_a?(String) %>
                     <% event.contact_twitter = [event.contact_twitter] %>


### PR DESCRIPTION
If we have a telegram channel in the list but no twitter handle, the html is missing ". "

Fix this by addint ". " to the contact string if no twitter handle is provided.