### PR TITLE
Add irc channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Adding your peer lab is a straightforward process: you need to add it to the [`e
 | `meetup_url` | A URL to link to (doesn't need to be a Meetup.com URL). |
 | `contact_twitter` | If someone has questions, who should they tweet? |
 | `contact_email` | If someone has questions, who should they email? |
+| `telegram_channel` | If someone has questions, where can he reach the community? |
+| `irc_channel` | If someone has questions, where can he reach the community? |
 
 ## Contributing
 

--- a/data/events.yml
+++ b/data/events.yml
@@ -244,3 +244,4 @@ peer_labs:
     meetup_url: https://mtk.bcnfs.org/doku.php?id=barcelona-kernel-peer-lab
     contact_twitter: bruggems
     contact_email: matthias.bgg@kernel.org
+    irc_channel: irc.freenode.net, bcn-kernel-peer-lab

--- a/source/find.html.erb
+++ b/source/find.html.erb
@@ -51,12 +51,12 @@ title: Find a Peer Lab
                     <% links = event.contact_twitter.map {|t| "<a href='https://twitter.com/#{t}'>@#{t}</a>" } %>
                     <% contact +=  "tweet to " + links.join(", ") + ". " %>
                <% end %>
-                  <% if event.telegram_channel %>
-                      <% t = event.telegram_channel.split(", ") %>
-                      <% links = "<a href='https://t.me/#{t[0]}'>#{t[1]}</a>" %>
-                      <% contact += "Our telegram channel: " + links + "." %>
-                  <% end %>
-                <%= contact %>
+               <% if event.telegram_channel %>
+                   <% t = event.telegram_channel.split(", ") %>
+                   <% links = "<a href='https://t.me/#{t[0]}'>#{t[1]}</a>" %>
+                   <% contact += "Our telegram channel: " + links + "." %>
+               <% end %>
+               <%= contact %>
               <% end %>
             </p>
           <% end %>

--- a/source/find.html.erb
+++ b/source/find.html.erb
@@ -54,7 +54,12 @@ title: Find a Peer Lab
                <% if event.telegram_channel %>
                    <% t = event.telegram_channel.split(", ") %>
                    <% links = "<a href='https://t.me/#{t[0]}'>#{t[1]}</a>" %>
-                   <% contact += "Our telegram channel: " + links + "." %>
+                   <% contact += "Our telegram channel: " + links + ". " %>
+               <% end %>
+               <% if event.irc_channel %>
+                   <% t = event.irc_channel.split(", ") %>
+		   <% links = "<a href='irc://#{t[0]}:6667/#{t[1]}'>#{t[1]}</a>" %>
+                   <% contact += "Our IRC channel: " + links + ". " %>
                <% end %>
                <%= contact %>
               <% end %>


### PR DESCRIPTION
The kernel community is still old-school. So in our peer lab we use an IRC channel.
I also updated the readme as it missed the option to add a telegram and irc channel.