### PR TITLE
Update events.yml

### DIFF
--- a/data/events.yml
+++ b/data/events.yml
@@ -5,12 +5,6 @@ peer_labs:
     contact_twitter: AlibekAshirali
     contact_email: ashiralialibek@gmail.com
 
-  - city: Amsterdam
-    schedule: Every Saturday, 9:00am
-    location: The Coffee Room, Kinkerstraat 110
-    meetup_url: https://www.meetup.com/Appsterdam/
-    contact_twitter: samuelgoodwin
-
   - city: Astana, Kazakhstan
     schedule: Every Sunday, 12:00am
     location: Starbucks, Mega Silkway, Kabanbai Batyra street 62, Astana


### PR DESCRIPTION
Amsterdam Peer Lab is no more, so it's off the list.